### PR TITLE
perf: use rules_js Bazel 6 optimized fs patches if using Bazel 6 and experimental_allow_unresolved_symlinks is on

### DIFF
--- a/cypress/defs.bzl
+++ b/cypress/defs.bzl
@@ -45,6 +45,10 @@ def cypress_test(name, cypress = "//:node_modules/cypress", **kwargs):
             "@aspect_rules_js//js/private:enable_runfiles": True,
             "//conditions:default": False,
         }),
+        unresolved_symlinks_enabled = select({
+            "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
+            "//conditions:default": False,
+        }),
         **kwargs
     )
 
@@ -84,6 +88,10 @@ def cypress_module_test(name, runner, cypress = "//:node_modules/cypress", **kwa
         name = name,
         enable_runfiles = select({
             "@aspect_rules_js//js/private:enable_runfiles": True,
+            "//conditions:default": False,
+        }),
+        unresolved_symlinks_enabled = select({
+            "@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks": True,
             "//conditions:default": False,
         }),
         entry_point = runner,

--- a/cypress/dependencies.bzl
+++ b/cypress/dependencies.bzl
@@ -25,9 +25,9 @@ def rules_cypress_dependencies():
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "2a1e5d4400e2b49f6d36785aa894412670a0babfe7054e733b6a8f23c1b41e26",
-        strip_prefix = "rules_js-1.23.1",
-        url = "https://github.com/aspect-build/rules_js/releases/download/v1.23.1/rules_js-v1.23.1.tar.gz",
+        sha256 = "aea8d12bdc4b40127e57fb3da5b61cbb17e969e7786471a71cbff0808c600bcb",
+        strip_prefix = "rules_js-1.24.1",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v1.24.1/rules_js-v1.24.1.tar.gz",
     )
 
     http_archive(


### PR DESCRIPTION
rules_js js_test base attributes that cypress_test uses requires setting `unresolved_symlinks_enabled` to True based on the `@aspect_rules_js//js/private:experimental_allow_unresolved_symlinks` condition to enable the optimized Bazel 6 patches only when the user is using Bazel 6 **AND** unresolved symlinks are enabled. They are enabled by default but they can be disabled by the user so we need to check anyway.

**Type of change**

- [x] Performance (a code change that improves performance)

**For changes visible to end-users**

- [x] Breaking change (this change will force users to change their own code or config)

For WORKSPACE users that are pinning `aspect_rules_js`, this bumps the minimum rules_js version required for rules_cypress compatibility to 1.24.0. WORKSPACE that get the version of rules_js transitively from `rules_cypress_dependencies` are not affected. bzlmod users are also not affected since bzlmod ensure the minimum version of rules_js that rules_cypress requires is used.

**Test plan**

- [x] Covered by existing test cases
