### PR TITLE
fix: rename LATEST_VERSION to LATEST_CYPRESS_VERSION

### DIFF
--- a/cypress/repositories.bzl
+++ b/cypress/repositories.bzl
@@ -7,7 +7,7 @@ See https://docs.bazel.build/versions/main/skylark/deploying.html#dependencies
 load("//cypress/private:toolchains_repo.bzl", "PLATFORMS", "toolchains_repo")
 load("//cypress/private:versions.bzl", "TOOL_VERSIONS")
 
-LATEST_VERSION = TOOL_VERSIONS.keys()[0]
+LATEST_CYPRESS_VERSION = TOOL_VERSIONS.keys()[0]
 
 ########
 # Remaining content of the file is only used to support toolchains.


### PR DESCRIPTION
See https://github.com/aspect-build/rules_js/issues/817

BREAKING CHANGE: LATEST_VERSION has been renamed to LATEST_CYPRESS_VERSION