### PR TITLE
feat: update to rules_js 1.27.0 and pickup fixed_args feature

### DIFF
--- a/cypress/dependencies.bzl
+++ b/cypress/dependencies.bzl
@@ -18,16 +18,16 @@ def rules_cypress_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "ee95bbc80f9ca219b93a8cc49fa19a2d4aa8649ddc9024f46abcdd33935753ca",
-        strip_prefix = "bazel-lib-1.29.2",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.29.2/bazel-lib-v1.29.2.tar.gz",
+        sha256 = "e3151d87910f69cf1fc88755392d7c878034a69d6499b287bcfc00b1cf9bb415",
+        strip_prefix = "bazel-lib-1.32.1",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v1.32.1/bazel-lib-v1.32.1.tar.gz",
     )
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "aea8d12bdc4b40127e57fb3da5b61cbb17e969e7786471a71cbff0808c600bcb",
-        strip_prefix = "rules_js-1.24.1",
-        url = "https://github.com/aspect-build/rules_js/releases/download/v1.24.1/rules_js-v1.24.1.tar.gz",
+        sha256 = "d8827db3c34fe47607a0668e86524fd85d5bd74f2bfca93046d07f890b5ad4df",
+        strip_prefix = "rules_js-1.27.0",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v1.27.0/rules_js-v1.27.0.tar.gz",
     )
 
     http_archive(

--- a/cypress/private/cypress_test.bzl
+++ b/cypress/private/cypress_test.bzl
@@ -1,3 +1,5 @@
+"cypress_test rule."
+
 load("@aspect_rules_js//js:libs.bzl", "js_binary_lib", "js_lib_helpers")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
@@ -40,6 +42,7 @@ def _impl(ctx):
         ctx,
         log_prefix_rule_set = "aspect_rules_cypess",
         log_prefix_rule = "cypress_node_test",
+        fixed_args = ctx.attr.fixed_args,
         fixed_env = {
             "CYPRESS_RUN_BINARY": cypress_bin,
             "HOME": "$$TEST_TMPDIR",


### PR DESCRIPTION
rules_js v1.27.0 adds a new fixed_args feature to js_binary & js_test that can be trivially added to jest_test.

---

### Type of change

- New feature or functionality (change which adds functionality)
