### PR TITLE
Make module_test runner & example handle failures correctly

### DIFF
--- a/cypress/tests/module_test/runner.js
+++ b/cypress/tests/module_test/runner.js
@@ -1,9 +1,26 @@
 const cypress = require('cypress')
 
-cypress.run({
-  headless: true,
-}).then(result => {
-  if (result.status === 'failed') {
-    process.exit(1);
-  }
-})
+async function main() {
+    try {
+        const result = await cypress.run({
+            headless: true,
+        })
+
+        // If any tests have failed, results.failures is non-zero, some tests have failed
+        if (result.failures) {
+            console.error('One or more cypress tests have failed')
+            console.error(result.message)
+            process.exit(1)
+        }
+
+        if (result.status !== 'finished') {
+            console.error('Cypress tests failed with status', result.status)
+            process.exit(2)
+        }
+    } catch (e) {
+        console.error("Cypress encountered unexpected exception. Exiting.", e)
+        process.exit(3)
+    }
+}
+
+main();

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -20,13 +20,30 @@ Example `runner.js`:
 ```
 const cypress = require('cypress')
 
-cypress.run({
-headless: true,
-}).then(result => {
-if (result.status === 'failed') {
-    process.exit(1);
+async function main() {
+    try {
+        const result = await cypress.run({
+            headless: true,
+        })
+
+        // If any tests have failed, results.failures is non-zero, some tests have failed
+        if (result.failures) {
+            console.error('One or more cypress tests have failed')
+            console.error(result.message)
+            process.exit(1)
+        }
+
+        if (result.status !== 'finished') {
+            console.error('Cypress tests failed with status', result.status)
+            process.exit(2)
+        }
+    } catch (e) {
+        console.error("Cypress encountered unexpected exception. Exiting.", e)
+        process.exit(3)
+    }
 }
-})
+
+main();
 ```
 
 


### PR DESCRIPTION
The existing runner.js wouldn't exit w/ a non-zero code if either a test fails, or cypress.run threw an exception. This will handle both cases

This also exposes a bug on linux where if you run `//cypress/tests/module_test:module_test` on linux, it will fail with 
```
Error: EROFS: read-only file system, open '/home/ubuntu/.cache/bazel/_bazel_ubuntu/3c3b515e9016ce6d22b6ff24560854f0/execroot/aspect_rules_cypress/bazel-out/k8-fastbuild/bin/external/cypress_linux-x64/binary_state.json'
```
which wasn't being caught before.

Fixes #44

---

### Type of change

- Bug fix (change which fixes an issue)
- Documentation (updates to documentation or READMEs)

### Test plan

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
