### PR TITLE
fix: incorrect linux checksums

### DIFF
--- a/cypress/private/versions.bzl
+++ b/cypress/private/versions.bzl
@@ -6,22 +6,22 @@ TOOL_VERSIONS = {
     "13.3.1": {
         "darwin-x64": "417c5f1d77e15c8aef0a55f155c16c3dbbc637f918c1e51f8fec6eb1c73a9ba9",
         "darwin-arm64": "143d905779c0b0a8a9049b0eb68b4b156db3d838d4546ce5082a8f7bd5dc5232",
-        "linux-x64": "a165aa290d23d03f191852df2e8c3cb25ddccf1d4e226518a0a217f4ec405328",
-        "linux-arm64": "b51810d7fda748f67d5d875d5e265ee22bb394af2bb4a545b78c99f1aae91cb0",
+        "linux-x64": "bb0ddd980bd82792a477b1c39ce8a0a7b275481031c559c065c94f1131151b0c",
+        "linux-arm64": "fbca9958e2a153f3f1ffdef1bb506db65401a8586229b9d9424cd16228d0353d",
         "win32-x64": "acf1e478634e4da254bd7c3695d9032010c2ed17955e7339e1ea7d79cf8c9f7b",
     },
     "12.12.0": {
         "darwin-x64": "53ddd917112a2c5c3c22d12f5bcffda596474c7cd0932a997e575b2b97ae36c0",
         "darwin-arm64": "2daadfe4431a98f9dc6442c155239aaed2746b12a59721424e3b5fdaaf27c766",
-        "linux-x64": "18bf251f683e0b0ca70918c2a51b7a457be6e5298be52203bd16d4e0eb361837",
-        "linux-arm64": "1f754c912eb719d4ac4abe31f3cc6d5b65cf08e0266cf6808f376c099928c88e",
+        "linux-x64": "7f41d45da094380cc0d6716c8357b60f9c9304c2475cf502ea60649f040d52ad",
+        "linux-arm64": "55531b5ba8d03a979a5ef92981d27964583897c652eec3788f24ec8677d05dd2",
         "win32-x64": "ffc47314ce5f74888066bc4a15ee18d375ee9680f9cca1b94eda7293e1dea4e5",
     },
     "12.3.0": {
         "darwin-x64": "beae3678dd859ce89cc45c377eef97b67558ee1f2a0079e9b4c824260ef3801a",
         "darwin-arm64": "bb08f247110dda9b180d2552a661b8669441f931b0332d818c306a14e8c7071a",
-        "linux-x64": "57dd85936373e6ce2ae5378f9035a3ad118899341e0c6e71783c3e58c039ce92",
-        "linux-arm64": "47c1188506b11644a332ab0949eab0b33179a64e4857e561d3c836c6f6f2cadf",
+        "linux-x64": "3a300d6c903a8f5fced488183dcc7faa06e9df14c946d6dab4b5822ec738e9cd",
+        "linux-arm64": "501671011a63fd450b87e1cae1b3ba3fabccf37e9c1c8c26e1d5f189f9afe688",
         "win32-x64": "639a0e0ca5498fc5330064c3fa441c741e6b6cd01234bfa9851de9a33f4f56a6",
     },
     "10.8.0": {


### PR DESCRIPTION
---

### Summary 

The checksums seem to have changed for the linux versions. This updates all of the ones that have changed by running `scripts/mirror_releases.sh` for all existing versions in `versions.bzl`. 

### Motivation

My CI runs are failing with a checksum validation error:
```
ERROR: An error occurred during the fetch of repository 'cypress_linux-x64':
   Traceback (most recent call last):
	File "/home/runner/.cache/bazel/_bazel_runner/f11a8be521d5e75cfb1ae3f1c16635c8/external/aspect_rules_cypress/cypress/repositories.bzl", line 27, column 40, in _cypress_repo_impl
		repository_ctx.download_and_extract(
Error in download_and_extract: java.io.IOException: Error downloading [https://cdn.cypress.io/desktop/12.3.0/linux-x64/cypress.zip] to /home/runner/.cache/bazel/_bazel_runner/f11a8be521d5e75cfb1ae3f1c16635c8/external/cypress_linux-x64/temp629800849139[56](https://github.com/jackvincentnz/lab/actions/runs/7592287327/job/20681466740?pr=248#step:5:57)60268/cypress.zip: Checksum was 3a300d6c903a8f5fced488183dcc7faa06e9df14c946d6dab4b5822ec738e9cd but wanted 57dd85936373e6ce2ae5378f9035a3ad118899341e0c6e71783c3e58c039ce92
ERROR: /home/runner/work/lab/lab/WORKSPACE:437:28: fetching cypress_repositories rule //external:cypress_linux-x64: Traceback (most recent call last):
	File "/home/runner/.cache/bazel/_bazel_runner/f11a8be521d5e75cfb1ae3f1c16635c8/external/aspect_rules_cypress/cypress/repositories.bzl", line 27, column 40, in _cypress_repo_impl
		repository_ctx.download_and_extract(
Error in download_and_extract: java.io.IOException: Error downloading [https://cdn.cypress.io/desktop/12.3.0/linux-x64/cypress.zip] to /home/runner/.cache/bazel/_bazel_runner/f11a8be521d5e75cfb1ae3f1c16635c8/external/cypress_linux-x64/temp6298008491395660268/cypress.zip: Checksum was 3a300d6c903a8f5fced488183dcc7faa06e9df14c946d6dab4b5822ec738e9cd but wanted [57](https://github.com/jackvincentnz/lab/actions/runs/7592287327/job/20681466740?pr=248#step:5:58)dd85936373e6ce2ae5378f9035a3ad118899341e0c6e71783c3e58c039ce92
ERROR: no such package '@@cypress_linux-x64//': java.io.IOException: Error downloading [https://cdn.cypress.io/desktop/12.3.0/linux-x64/cypress.zip] to /home/runner/.cache/bazel/_bazel_runner/f11a8be521d5e75cfb1ae3f1c16635c8/external/cypress_linux-x64/temp6298008491395660268/cypress.zip: Checksum was 3a300d6c903a8f5fced488183dcc7faa06e9df14c946d6dab4b[58](https://github.com/jackvincentnz/lab/actions/runs/7592287327/job/20681466740?pr=248#step:5:59)22ec738e9cd but wanted 57dd8[59](https://github.com/jackvincentnz/lab/actions/runs/7592287327/job/20681466740?pr=248#step:5:60)36373e6ce2ae5378f9035a3ad118899341e0c6e71783c3e58c039ce92
```

### Type of change

- Bug fix (change which fixes an issue)

### Test plan

- Covered by existing test cases
