### PR TITLE
fix: Set display to 0 to prevent xvfb collisions

### DIFF
--- a/cypress/private/cypress_test.bzl
+++ b/cypress/private/cypress_test.bzl
@@ -34,6 +34,7 @@ def _impl(ctx):
             "CYPRESS_RUN_BINARY": cypress_bin,
             "HOME": "$$TEST_TMPDIR",
             "XDG_CONFIG_HOME": "$$TEST_TMPDIR",
+            "DISPLAY": "0",
         },
     )
 


### PR DESCRIPTION
---

### Type of change

- Bug fix (change which fixes an issue)

### Test plan
- New test cases added
(using a cypress version 13.6.6 required this change on macOS)