### PR TITLE
fix: don't register toolchains in MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,12 +6,6 @@ module(
     compatibility_level = 1,
 )
 
-cypress = use_extension("//cypress:extensions.bzl", "cypress")
-cypress.toolchain(cypress_version = "12.3.0")
-use_repo(cypress, "cypress_toolchains")
-
-register_toolchains("@cypress_toolchains//:all")
-
 bazel_dep(name = "aspect_bazel_lib", version = "1.42.3")
 bazel_dep(name = "aspect_rules_js", version = "1.41.2")
 bazel_dep(name = "bazel_skylib", version = "1.4.1")

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -30,13 +30,6 @@ nodejs_register_toolchains(
     node_version = DEFAULT_NODE_VERSION,
 )
 
-load("@aspect_rules_cypress//cypress:repositories.bzl", "cypress_register_toolchains")
-
-cypress_register_toolchains(
-    name = "cypress",
-    cypress_version = "12.3.0",
-)
-
 # For running our own unit tests
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 

--- a/e2e/workspace/MODULE.bazel
+++ b/e2e/workspace/MODULE.bazel
@@ -4,6 +4,12 @@ local_path_override(
     path = "../..",
 )
 
+cypress = use_extension("@aspect_rules_cypress//cypress:extensions.bzl", "cypress")
+cypress.toolchain(cypress_version = "12.12.0")
+use_repo(cypress, "cypress_toolchains")
+
+register_toolchains("@cypress_toolchains//:all")
+
 bazel_dep(name = "aspect_rules_js", version = "1.41.2", dev_dependency = True)
 bazel_dep(name = "bazel_features", version = "1.9.0", dev_dependency = True)
 


### PR DESCRIPTION
Pre-factor from https://github.com/aspect-build/rules_cypress/pull/66

A follow-up will add the MODULE.bazel snippet to the release notes that instructs users on how to configure rules_cypress with bzlmod