### PR TITLE
chore: various cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,14 @@
 bazel-*
 .bazelrc.user
-node_modules/
+node_modules
 .pnpm-*
 
 .idea/
 .ijwb/
 .vscode
 .DS_Store
+
+.github/pull_request_template.md
 
 # Bazel's MODULE lockfile isn't ready to check in yet as of Bazel 7.1.
 # Do allow for it to be created, however, since it gives a performance boost for local development.

--- a/cypress/defs.bzl
+++ b/cypress/defs.bzl
@@ -112,15 +112,25 @@ def cypress_module_test(
 
     Example `runner.js`:
     ```
-    const cypress = require('cypress')
+    async function main() {
+    const result = await cypress.run({
+        headless: true,
+    });
 
-    cypress.run({
-    headless: true,
-    }).then(result => {
-    if (result.status === 'failed') {
-        process.exit(1);
+    // If any tests have failed, results.failures is non-zero, some tests have failed
+    if (result.failures) {
+        console.error("One or more cypress tests have failed");
+        console.error(result.message);
+        return 1;
     }
-    })
+
+    if (result.status === "failed") {
+        console.log("Cypress exited with a failure status");
+        return 2;
+    }
+
+    return 0;
+    }
     ```
 
     In most scenarios, it is easier to use cypress_test. But in some scenarios, you may need more flexibility:

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -18,15 +18,25 @@ You will provide a test runner, via the runner attribute, which is expected to c
 
 Example `runner.js`:
 ```
-const cypress = require('cypress')
+async function main() {
+const result = await cypress.run({
+    headless: true,
+});
 
-cypress.run({
-headless: true,
-}).then(result => {
-if (result.status === 'failed') {
-    process.exit(1);
+// If any tests have failed, results.failures is non-zero, some tests have failed
+if (result.failures) {
+    console.error("One or more cypress tests have failed");
+    console.error(result.message);
+    return 1;
 }
-})
+
+if (result.status === "failed") {
+    console.log("Cypress exited with a failure status");
+    return 2;
+}
+
+return 0;
+}
 ```
 
 In most scenarios, it is easier to use cypress_test. But in some scenarios, you may need more flexibility:

--- a/e2e/workspace/MODULE.bazel
+++ b/e2e/workspace/MODULE.bazel
@@ -5,7 +5,7 @@ local_path_override(
 )
 
 cypress = use_extension("@aspect_rules_cypress//cypress:extensions.bzl", "cypress", dev_dependency = True)
-cypress.toolchain(cypress_version = "12.12.0")
+cypress.toolchain(cypress_version = "13.6.6")
 use_repo(cypress, "cypress_toolchains")
 
 register_toolchains("@cypress_toolchains//:all")
@@ -16,6 +16,10 @@ bazel_dep(name = "bazel_features", version = "1.9.0", dev_dependency = True)
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
 npm.npm_translate_lock(
     name = "npm",
+    lifecycle_hooks_exclude = [
+        # Speed up installation by disabling cypress binary install. Optional.
+        "cypress",
+    ],
     npmrc = "//:.npmrc",
     pnpm_lock = "//:pnpm-lock.yaml",
     verify_node_modules_ignored = "//:.bazelignore",

--- a/e2e/workspace/WORKSPACE.bazel
+++ b/e2e/workspace/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@aspect_rules_cypress//cypress:repositories.bzl", "cypress_register_toolch
 
 cypress_register_toolchains(
     name = "cypress",
-    cypress_version = "12.12.0",
+    cypress_version = "13.6.6",
 )
 
 load("@aspect_rules_js//js:repositories.bzl", "rules_js_dependencies")
@@ -44,6 +44,10 @@ load("@aspect_rules_js//npm:npm_import.bzl", "npm_translate_lock")
 
 npm_translate_lock(
     name = "npm",
+    lifecycle_hooks_exclude = [
+        # Speed up installation by disabling cypress binary install. Optional.
+        "cypress",
+    ],
     npmrc = "//:.npmrc",
     pnpm_lock = "//:pnpm-lock.yaml",
     verify_node_modules_ignored = "//:.bazelignore",

--- a/e2e/workspace/cli_test/BUILD
+++ b/e2e/workspace/cli_test/BUILD
@@ -2,6 +2,7 @@ load("@aspect_rules_cypress//cypress:defs.bzl", "cypress_test")
 
 cypress_test(
     name = "cli_test",
+    timeout = "short",
     args = [
         "run",
         "--config-file=cypress.config.ts",

--- a/e2e/workspace/cli_test/cli_test.cy.ts
+++ b/e2e/workspace/cli_test/cli_test.cy.ts
@@ -1,5 +1,5 @@
-describe('My First Test', () => {
-    it('Does not do much!', () => {
-        expect(true).to.equal(true)
-    })
-})
+describe("My First Test", () => {
+  it("Does not do much!", () => {
+    expect(true).to.equal(true);
+  });
+});

--- a/e2e/workspace/cli_test/cypress.config.ts
+++ b/e2e/workspace/cli_test/cypress.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig } from "cypress";
 
+// Set XVFB_DISPLAY_NUM to instruct cypress what port to use during CI and prevent port collision.
+process.env.XVFB_DISPLAY_NUM = Math.floor(Math.random() * 99999).toString();
+
 export default defineConfig({
   e2e: {
     specPattern: ["cli_test.cy.ts"],

--- a/e2e/workspace/cli_test/cypress.config.ts
+++ b/e2e/workspace/cli_test/cypress.config.ts
@@ -1,13 +1,13 @@
-import { defineConfig } from 'cypress'
+import { defineConfig } from "cypress";
 
 export default defineConfig({
   e2e: {
     specPattern: ["cli_test.cy.ts"],
     supportFile: false,
     setupNodeEvents(on, config) {
-      on('before:browser:launch', (browser, launchOptions) => {
-        launchOptions.args.push("--disable-gpu-shader-disk-cache")
-      })
-    }
+      on("before:browser:launch", (browser, launchOptions) => {
+        launchOptions.args.push("--disable-gpu-shader-disk-cache");
+      });
+    },
   },
-})
+});

--- a/e2e/workspace/cli_test/tsconfig.json
+++ b/e2e/workspace/cli_test/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
         "target": "ES2022",
-        "types": ["cypress"]
+        "types": ["cypress", "node"]
     }
 }

--- a/e2e/workspace/cli_test/tsconfig.json
+++ b/e2e/workspace/cli_test/tsconfig.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
-        "target": "ES2022"
+        "target": "ES2022",
+        "types": ["cypress"]
     }
 }

--- a/e2e/workspace/module_test/BUILD.bazel
+++ b/e2e/workspace/module_test/BUILD.bazel
@@ -2,6 +2,7 @@ load("@aspect_rules_cypress//cypress:defs.bzl", "cypress_module_test")
 
 cypress_module_test(
     name = "module_test",
+    timeout = "short",
     data = [
         "cypress.config.js",
         "module_test.cy.js",

--- a/e2e/workspace/module_test/cypress.config.js
+++ b/e2e/workspace/module_test/cypress.config.js
@@ -1,5 +1,8 @@
 const { defineConfig } = require("cypress");
 
+// Set XVFB_DISPLAY_NUM to instruct cypress what port to use during CI and prevent port collision.
+process.env.XVFB_DISPLAY_NUM = Math.floor(Math.random() * 99999).toString();
+
 module.exports = defineConfig({
   e2e: {
     specPattern: ["*.cy.js"],

--- a/e2e/workspace/module_test/cypress.config.js
+++ b/e2e/workspace/module_test/cypress.config.js
@@ -1,13 +1,13 @@
-const { defineConfig } = require('cypress')
+const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
   e2e: {
     specPattern: ["*.cy.js"],
     supportFile: false,
-    setupNodeEvents(on, config) {
-      on('before:browser:launch', (browser = {}, launchOptions) => {
-        launchOptions.args.push("--disable-gpu-shader-disk-cache")
-      })
-    }
+    setupNodeEvents(on, _config) {
+      on("before:browser:launch", (_browser, launchOptions) => {
+        launchOptions.args.push("--disable-gpu-shader-disk-cache");
+      });
+    },
   },
-})
+});

--- a/e2e/workspace/module_test/module_test.cy.js
+++ b/e2e/workspace/module_test/module_test.cy.js
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 
-describe('My First Test', () => {
-    it('Does not do much!', () => {
-        expect(true).to.equal(true)
-    })
-})
+describe("My First Test", () => {
+  it("Does not do much!", () => {
+    expect(true).to.equal(true);
+  });
+});

--- a/e2e/workspace/module_test/runner.js
+++ b/e2e/workspace/module_test/runner.js
@@ -12,8 +12,8 @@ async function main() {
     return 1;
   }
 
-  if (result.status !== "finished") {
-    console.error("Cypress tests failed with status", result.status);
+  if (result.status === "failed") {
+    console.log("Cypress exited with a failure status");
     return 2;
   }
 

--- a/e2e/workspace/package.json
+++ b/e2e/workspace/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Tests for cypress bazel rules",
   "dependencies": {
-    "cypress": "12.12.0",
+    "cypress": "13.6.6",
     "express": "^4.19.2",
     "typescript": "4.9.5"
   }

--- a/e2e/workspace/package.json
+++ b/e2e/workspace/package.json
@@ -6,5 +6,8 @@
     "cypress": "13.6.6",
     "express": "^4.19.2",
     "typescript": "4.9.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.8"
   }
 }

--- a/e2e/workspace/pnpm-lock.yaml
+++ b/e2e/workspace/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '6.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 dependencies:
@@ -14,6 +14,11 @@ dependencies:
   typescript:
     specifier: 4.9.5
     version: 4.9.5
+
+devDependencies:
+  '@types/node':
+    specifier: ^20.12.8
+    version: 20.12.8
 
 packages:
 
@@ -57,11 +62,10 @@ packages:
       - supports-color
     dev: false
 
-  /@types/node@14.18.63:
-    resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
-    requiresBuild: true
-    dev: false
-    optional: true
+  /@types/node@20.12.8:
+    resolution: {integrity: sha512-NU0rJLJnshZWdE/097cdCBbyW1h4hEg0xpovcoAQYHl8dnEyp/NAOiE45pvc+Bd1Dt+2r94v2eGFpQJ4R7g+2w==}
+    dependencies:
+      undici-types: 5.26.5
 
   /@types/sinonjs__fake-timers@8.1.1:
     resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
@@ -75,7 +79,7 @@ packages:
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
     requiresBuild: true
     dependencies:
-      '@types/node': 14.18.63
+      '@types/node': 20.12.8
     dev: false
     optional: true
 
@@ -1405,6 +1409,9 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: false
+
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
 
   /universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}

--- a/e2e/workspace/pnpm-lock.yaml
+++ b/e2e/workspace/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   cypress:
-    specifier: 12.12.0
-    version: 12.12.0
+    specifier: 13.6.6
+    version: 13.6.6
   express:
     specifier: ^4.19.2
     version: 4.19.2
@@ -24,8 +24,8 @@ packages:
     dev: false
     optional: true
 
-  /@cypress/request@2.88.12:
-    resolution: {integrity: sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==}
+  /@cypress/request@3.0.1:
+    resolution: {integrity: sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==}
     engines: {node: '>= 6'}
     dependencies:
       aws-sign2: 0.7.0
@@ -59,7 +59,9 @@ packages:
 
   /@types/node@14.18.63:
     resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
+    requiresBuild: true
     dev: false
+    optional: true
 
   /@types/sinonjs__fake-timers@8.1.1:
     resolution: {integrity: sha512-0kSuKjAS0TrGLJ0M/+8MaFkGsQhZpB6pxOmvS3K8FYI72K//YmdfoW9X2qPsAKh1mkwxGD5zib9s1FIFed6E8g==}
@@ -349,15 +351,14 @@ packages:
       which: 2.0.2
     dev: false
 
-  /cypress@12.12.0:
-    resolution: {integrity: sha512-UU5wFQ7SMVCR/hyKok/KmzG6fpZgBHHfrXcHzDmPHWrT+UUetxFzQgt7cxCszlwfozckzwkd22dxMwl/vNkWRw==}
-    engines: {node: ^14.0.0 || ^16.0.0 || >=18.0.0}
+  /cypress@13.6.6:
+    resolution: {integrity: sha512-S+2S9S94611hXimH9a3EAYt81QM913ZVA03pUmGDfLTFa5gyp85NJ8dJGSlEAEmyRsYkioS1TtnWtbv/Fzt11A==}
+    engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@cypress/request': 2.88.12
+      '@cypress/request': 3.0.1
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
-      '@types/node': 14.18.63
       '@types/sinonjs__fake-timers': 8.1.1
       '@types/sizzle': 2.3.8
       arch: 2.2.0
@@ -390,6 +391,7 @@ packages:
       minimist: 1.2.8
       ospath: 1.2.2
       pretty-bytes: 5.6.0
+      process: 0.11.10
       proxy-from-env: 1.0.0
       request-progress: 3.0.0
       semver: 7.6.0
@@ -1082,6 +1084,11 @@ packages:
   /pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
+    dev: false
+
+  /process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
     dev: false
 
   /proxy-addr@2.0.7:

--- a/e2e/workspace/server_example/BUILD.bazel
+++ b/e2e/workspace/server_example/BUILD.bazel
@@ -9,6 +9,7 @@ js_binary(
 
 cypress_test(
     name = "server_example",
+    timeout = "short",
     args = [
         "run",
         "--config-file=cypress.config.js",

--- a/e2e/workspace/server_example/cypress.config.js
+++ b/e2e/workspace/server_example/cypress.config.js
@@ -3,6 +3,9 @@ const { defineConfig } = require("cypress");
 const { spawn } = require("node:child_process");
 const { join } = require("path");
 
+// Set XVFB_DISPLAY_NUM to instruct cypress what port to use during CI and prevent port collision.
+process.env.XVFB_DISPLAY_NUM = Math.floor(Math.random() * 99999).toString();
+
 module.exports = defineConfig({
   e2e: {
     specPattern: ["server_example_test.cy.js"],

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+	"devDependencies": {
+		"prettier": "^3.2.5"
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,15 @@
+lockfileVersion: 5.4
+
+specifiers:
+  prettier: ^3.2.5
+
+devDependencies:
+  prettier: 3.2.5
+
+packages:
+
+  /prettier/3.2.5:
+    resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true


### PR DESCRIPTION
- Upgrade e2e version of cypres to 13.6.6
- Run prettier
- Set test timeouts to short
- Disable cypress lifecycle for cypress

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
