### PR TITLE
fix: Remove select statements from generated repo

### DIFF
--- a/cypress/BUILD.darwin.cypress
+++ b/cypress/BUILD.darwin.cypress
@@ -1,0 +1,17 @@
+# BUILD file inserted into the cypress toolchain repository
+
+load("@aspect_rules_cypress//cypress:toolchain.bzl", "cypress_toolchain")
+load("@aspect_bazel_lib//lib:copy_directory.bzl", "copy_directory")
+load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+
+filegroup(
+    name = "files",
+    srcs = ["Cypress.app", "binary_state.json"],
+    visibility = ["//visibility:public"],
+)
+
+cypress_toolchain(
+    name = "cypress_toolchain", 
+    target_tool = "Cypress.app/Contents/MacOS/Cypress",
+    target_tool_files = ":files",
+)

--- a/cypress/BUILD.linux.cypress
+++ b/cypress/BUILD.linux.cypress
@@ -4,18 +4,11 @@ load("@aspect_rules_cypress//cypress:toolchain.bzl", "cypress_toolchain")
 load("@aspect_bazel_lib//lib:copy_directory.bzl", "copy_directory")
 load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 
-
 # Copy the cypress binary directory to make it RBE compatible.
 copy_directory(
     name = "cypress_binary",
-    src = select({
-        "@bazel_tools//src/conditions:darwin": "Cypress.app",
-        "//conditions:default": "Cypress",
-    }),
-    out = select({
-        "@bazel_tools//src/conditions:darwin": "Cypress.app",
-        "//conditions:default": "Cypress",
-    }),
+    src = "Cypress",
+    out = "Cypress",
     tags = ["manual"]
 )
 
@@ -27,18 +20,12 @@ copy_to_bin(
 
 filegroup(
     name = "files",
-    srcs = select({
-        "@bazel_tools//src/conditions:darwin": ["Cypress.app", "binary_state.json"],
-        "//conditions:default": [":cypress_binary", ":binary_state_file"]
-    }),
+    srcs = [":cypress_binary", ":binary_state_file"],
     visibility = ["//visibility:public"],
 )
 
 cypress_toolchain(
     name = "cypress_toolchain", 
-    target_tool = select({
-        "@bazel_tools//src/conditions:darwin": "Cypress.app/Contents/MacOS/Cypress",
-        "//conditions:default": "Cypress/Cypress",
-    }),
+    target_tool = "Cypress/Cypress",
     target_tool_files = ":files",
 )

--- a/cypress/repositories.bzl
+++ b/cypress/repositories.bzl
@@ -32,7 +32,10 @@ def _cypress_repo_impl(repository_ctx):
     repository_ctx.file("binary_state.json", binary_state_json_contents)
 
     # Base BUILD file for this repository
-    repository_ctx.template("BUILD.bazel", Label("//cypress:BUILD.cypress"))
+    if repository_ctx.attr.platform.startswith("darwin-"):
+        repository_ctx.template("BUILD.bazel", Label("//cypress:BUILD.darwin.cypress"))
+    else:
+        repository_ctx.template("BUILD.bazel", Label("//cypress:BUILD.linux.cypress"))
 
 cypress_repositories = repository_rule(
     _cypress_repo_impl,


### PR DESCRIPTION
Using a select statement breaks things when the
execution platform and host platform are
mismatched

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: no
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: no

### Test plan

- Manual testing; please provide instructions so we can reproduce:
  Ran on local repository to verify
