### PR TITLE
fix: set XVFB_DISPLAY_NUM to instruct cypress what port to use during CI and prevent port collision

### DIFF
--- a/e2e/workspace/cli_test/cypress.config.ts
+++ b/e2e/workspace/cli_test/cypress.config.ts
@@ -1,13 +1,16 @@
-import { defineConfig } from 'cypress'
+import { defineConfig } from "cypress";
+
+// Set XVFB_DISPLAY_NUM to instruct cypress what port to use during CI and prevent port collision.
+process.env.XVFB_DISPLAY_NUM = Math.floor(Math.random() * 99999).toString();
 
 export default defineConfig({
   e2e: {
     specPattern: ["cli_test.cy.ts"],
     supportFile: false,
     setupNodeEvents(on, config) {
-      on('before:browser:launch', (browser, launchOptions) => {
-        launchOptions.args.push("--disable-gpu-shader-disk-cache")
-      })
-    }
+      on("before:browser:launch", (browser, launchOptions) => {
+        launchOptions.args.push("--disable-gpu-shader-disk-cache");
+      });
+    },
   },
-})
+});


### PR DESCRIPTION
<!-- Delete this comment! 
Include a summary of your changes, links to related issue(s), relevant motivation and context for why you made the change, how you arrived at this design, or alternatives considered.

For repositories that use a squash merge strategy, the pull request description may also be used as the landed commit description ensuring that useful information ends up in the git log.
-->

---

### Changes are visible to end-users: yes/no

<!-- If no, please delete this section. -->

- Searched for relevant documentation and updated as needed: yes/no
- Breaking change (forces users to change their own code or config): yes/no
- Suggested release notes appear below: yes/no

### Test plan

<!-- Delete any which do not apply -->

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
