### PR TITLE
refactor: don't default chdir to package_name() in _cypress_test_macro [BREAKING]

### DIFF
--- a/cypress/defs.bzl
+++ b/cypress/defs.bzl
@@ -22,7 +22,6 @@ def _cypress_test_macro(name, entry_point, cypress, disable_sandbox, **kwargs):
         data = kwargs.pop("data", []) + [
             cypress,
         ],
-        chdir = native.package_name(),
         enable_runfiles = select({
             "@aspect_rules_js//js/private:enable_runfiles": True,
             "//conditions:default": False,

--- a/e2e/workspace/cli_test/BUILD
+++ b/e2e/workspace/cli_test/BUILD
@@ -5,7 +5,7 @@ cypress_test(
     timeout = "short",
     args = [
         "run",
-        "--config-file=cypress.config.ts",
+        "--config-file=cli_test/cypress.config.ts",
     ],
     data = [
         "cli_test.cy.ts",

--- a/e2e/workspace/cli_test/cypress.config.ts
+++ b/e2e/workspace/cli_test/cypress.config.ts
@@ -5,7 +5,7 @@ process.env.XVFB_DISPLAY_NUM = Math.floor(Math.random() * 99999).toString();
 
 export default defineConfig({
   e2e: {
-    specPattern: ["cli_test.cy.ts"],
+    specPattern: ["cli_test/cli_test.cy.ts"],
     supportFile: false,
     setupNodeEvents(on, config) {
       on("before:browser:launch", (browser, launchOptions) => {

--- a/e2e/workspace/module_test/BUILD.bazel
+++ b/e2e/workspace/module_test/BUILD.bazel
@@ -3,6 +3,7 @@ load("@aspect_rules_cypress//cypress:defs.bzl", "cypress_module_test")
 cypress_module_test(
     name = "module_test",
     timeout = "short",
+    chdir = package_name(),
     data = [
         "cypress.config.js",
         "module_test.cy.js",

--- a/e2e/workspace/server_example/BUILD.bazel
+++ b/e2e/workspace/server_example/BUILD.bazel
@@ -12,7 +12,7 @@ cypress_test(
     timeout = "short",
     args = [
         "run",
-        "--config-file=cypress.config.js",
+        "--config-file=server_example/cypress.config.js",
     ],
     data = [
         "cypress.config.js",

--- a/e2e/workspace/server_example/cypress.config.js
+++ b/e2e/workspace/server_example/cypress.config.js
@@ -8,7 +8,7 @@ process.env.XVFB_DISPLAY_NUM = Math.floor(Math.random() * 99999).toString();
 
 module.exports = defineConfig({
   e2e: {
-    specPattern: ["server_example_test.cy.js"],
+    specPattern: ["server_example/server_example_test.cy.js"],
     supportFile: false,
     setupNodeEvents(on, config) {
       // Use "before:browser:launch" to edit config values.
@@ -20,7 +20,7 @@ module.exports = defineConfig({
       const port = "3000";
       return new Promise((resolve, reject) => {
         // Launch the server
-        const serverProcess = spawn(join(__dirname, "server.sh"), [port], {
+        const serverProcess = spawn(join(process.cwd(), "server.sh"), [port], {
           // js_binary expects to be run at execroot, but cypress rule has changed pwd to where our test target was defined.
           cwd: `${process.env.TEST_SRCDIR}/${process.env.TEST_WORKSPACE}`,
         });


### PR DESCRIPTION
Related to Bazel Slack thread: https://bazelbuild.slack.com/archives/C04281DTLH0/p1714238140731229?thread_ts=1713995693.705169&cid=C04281DTLH0

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): yes
- Suggested release notes appear below: yes

BREAKING CHANGES

`cypress_test` and `cypress_module_test` no longer default `chdir` to `package_name()` under the hood. This is to align rules_cypress with the rest of the rules_js rulesets. Users must now set `chdir` explicitly on these rules.

### Test plan

- Covered by existing test cases
