### PR TITLE
chore: bump miminum dep to aspect_bazel_lib 2.7.6

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,7 +7,7 @@ module(
 )
 
 # Lower-bounds (minimum) versions for direct runtime dependencies
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.3")
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.6")
 bazel_dep(name = "aspect_rules_js", version = "2.0.0-alpha.6")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.5")

--- a/cypress/dependencies.bzl
+++ b/cypress/dependencies.bzl
@@ -18,9 +18,9 @@ def rules_cypress_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "87ab4ec479ebeb00d286266aca2068caeef1bb0b1765e8f71c7b6cfee6af4226",
-        strip_prefix = "bazel-lib-2.7.3",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.7.3/bazel-lib-v2.7.3.tar.gz",
+        sha256 = "b59781939f40c8bf148f4a71bd06e3027e15e40e98143ea5688b83531ec8528f",
+        strip_prefix = "bazel-lib-2.7.6",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.7.6/bazel-lib-v2.7.6.tar.gz",
     )
 
     http_archive(

--- a/e2e/workspace/MODULE.bazel
+++ b/e2e/workspace/MODULE.bazel
@@ -10,7 +10,7 @@ use_repo(cypress, "cypress_toolchains")
 
 register_toolchains("@cypress_toolchains//:all")
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.3", dev_dependency = True)
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.6", dev_dependency = True)
 bazel_dep(name = "aspect_rules_js", version = "2.0.0-alpha.6", dev_dependency = True)
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)


### PR DESCRIPTION
bazel-lib 2.7.3 has a bad URL in coreutils for darwin x86