### PR TITLE
chore: bump to rules_js 2.0.0-rc1 and minimum aspect_bazel_lib 2.7.7

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,8 +7,8 @@ module(
 )
 
 # Lower-bounds (minimum) versions for direct runtime dependencies
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.6")
-bazel_dep(name = "aspect_rules_js", version = "2.0.0-alpha.6")
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.7")
+bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc1")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.5")
 bazel_dep(name = "rules_nodejs", version = "6.1.0")

--- a/cypress/dependencies.bzl
+++ b/cypress/dependencies.bzl
@@ -18,16 +18,16 @@ def rules_cypress_dependencies():
 
     http_archive(
         name = "aspect_bazel_lib",
-        sha256 = "b59781939f40c8bf148f4a71bd06e3027e15e40e98143ea5688b83531ec8528f",
-        strip_prefix = "bazel-lib-2.7.6",
-        url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.7.6/bazel-lib-v2.7.6.tar.gz",
+        sha256 = "6d758a8f646ecee7a3e294fbe4386daafbe0e5966723009c290d493f227c390b",
+        strip_prefix = "bazel-lib-2.7.7",
+        url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.7.7/bazel-lib-v2.7.7.tar.gz",
     )
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "03d9e0c1da0ee9dd8ff52ba0f6ee5d173848c00ef4c85ec558aad0a9cf56ac46",
-        strip_prefix = "rules_js-2.0.0-alpha.6",
-        url = "https://github.com/aspect-build/rules_js/releases/download/v2.0.0-alpha.6/rules_js-v2.0.0-alpha.6.tar.gz",
+        sha256 = "7085e915cdba6f2dc0ce93bef59f5d040a539b510b840456b6ac7ccc2bee7886",
+        strip_prefix = "rules_js-2.0.0-rc1",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v2.0.0-rc1/rules_js-v2.0.0-rc1.tar.gz",
     )
 
     http_archive(

--- a/e2e/workspace/MODULE.bazel
+++ b/e2e/workspace/MODULE.bazel
@@ -10,8 +10,8 @@ use_repo(cypress, "cypress_toolchains")
 
 register_toolchains("@cypress_toolchains//:all")
 
-bazel_dep(name = "aspect_bazel_lib", version = "2.7.6", dev_dependency = True)
-bazel_dep(name = "aspect_rules_js", version = "2.0.0-alpha.6", dev_dependency = True)
+bazel_dep(name = "aspect_bazel_lib", version = "2.7.7", dev_dependency = True)
+bazel_dep(name = "aspect_rules_js", version = "2.0.0-rc1", dev_dependency = True)
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
 npm.npm_translate_lock(


### PR DESCRIPTION
aspect_bazel_lib min bump goes along with rules_js bump in https://github.com/aspect-build/rules_js/pull/1763 to pick up fix for copy_to_directory that affects npm_package: https://github.com/aspect-build/bazel-lib/pull/857.