### PR TITLE
chore: green up BCR presumbit CI

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,12 +1,12 @@
 bcr_test_module:
   module_path: "e2e/workspace"
   matrix:
-    bazel: ["7.x", "6.x"]
+    bazel: ["7.x"]
     platform: ["debian10", "macos", "ubuntu2004"]
   tasks:
     run_tests:
       name: "Run test module"
       bazel: ${{ bazel }}
       platform: ${{ platform }}
-      test_targets:
+      build_targets:
         - "//..."


### PR DESCRIPTION
For various reasons we can't build or test on Bazel 6.x on BCR pre-submit and we can't run `bazel test` on BCR pre-submit with Bazel 7. See failures here for more details: https://buildkite.com/bazel/bcr-presubmit/builds/7099.

This PR switches to just running `bazel build //...` on Bazel 7.x on BCR for pre-submit. Test coverage for now will only be on CI for the repo.
