### PR TITLE
feat: Create js_run_devserver target in macro

### DIFF
--- a/cypress/BUILD.bazel
+++ b/cypress/BUILD.bazel
@@ -32,6 +32,7 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         "@aspect_rules_cypress//cypress/private:cypress_test",
+        "@aspect_rules_js//js:defs",
         "@aspect_rules_js//js:libs",
     ],
 )

--- a/docs/defs.md
+++ b/docs/defs.md
@@ -73,6 +73,9 @@ The environment is bootstrapped by first setting the environment variable `CYPRE
 See documentation on what arguments the cypress CLI supports:
 https://docs.cypress.io/guides/guides/command-line#What-you-ll-learn
 
+Macro produces two targets:
+  - `[name]`: Test target which will invoke `cypress run`
+  - `[name].open`: Runnable target which will invoke `cypress open`. Meant to be used in conjunction with ibazel
 
 
 **PARAMETERS**

--- a/e2e/workspace/cli_test/BUILD
+++ b/e2e/workspace/cli_test/BUILD
@@ -4,7 +4,8 @@ cypress_test(
     name = "cli_test",
     timeout = "short",
     args = [
-        "run",
+        "--e2e",
+        "--browser=electron",
         "--config-file=cli_test/cypress.config.ts",
     ],
     data = [

--- a/e2e/workspace/server_example/BUILD.bazel
+++ b/e2e/workspace/server_example/BUILD.bazel
@@ -11,7 +11,8 @@ cypress_test(
     name = "server_example",
     timeout = "short",
     args = [
-        "run",
+        "--e2e",
+        "--browser=electron",
         "--config-file=server_example/cypress.config.js",
     ],
     data = [

--- a/e2e/workspace/server_example/cypress.config.js
+++ b/e2e/workspace/server_example/cypress.config.js
@@ -17,12 +17,12 @@ module.exports = defineConfig({
         launchOptions.args.push("--disable-gpu-shader-disk-cache");
       });
 
-      const port = "3000";
+      const port = "4000";
       return new Promise((resolve, reject) => {
         // Launch the server
         const workspaceRoot = join(
-          process.env.RUNFILES_DIR,
-          process.env.TEST_WORKSPACE,
+          process.env.JS_BINARY__RUNFILES,
+          process.env.TEST_WORKSPACE || '_main',
         );
         const serverProcess = spawn(
           join(workspaceRoot, "server_example/server_/server"),

--- a/e2e/workspace/server_example/server.js
+++ b/e2e/workspace/server_example/server.js
@@ -7,6 +7,7 @@ if (isNaN(port)) {
 }
 
 app.get("/", (req, res) => {
+  res.type('html');
   res.send(`
 <html>
     <body>


### PR DESCRIPTION
Every `cypress_test` the macro now generates
a supplementary target `[name].open` which runs
cypress using js_run_devserver. This allows users
to use ibazel to interactively update their tests.

---

### Changes are visible to end-users: yes

- Searched for relevant documentation and updated as needed: yes
- Breaking change (forces users to change their own code or config): no
- Suggested release notes appear below: yes

### Test plan

- Covered by existing test cases

`cypress_test` macro now creates another target with name `[name].open`. This target runs `cypress open` using js_run_devserver. It is meant to be run with `ibazel` so that your tests can be updated interactively.
