### PR TITLE
fix: Configure target_compatible_with toolchain to allow for cross-building

### DIFF
--- a/cypress/BUILD.cypress
+++ b/cypress/BUILD.cypress
@@ -8,14 +8,8 @@ load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
 # Copy the cypress binary directory to make it RBE compatible.
 copy_directory(
     name = "cypress_binary",
-    src = select({
-        "@bazel_tools//src/conditions:darwin": "Cypress.app",
-        "//conditions:default": "Cypress",
-    }),
-    out = select({
-        "@bazel_tools//src/conditions:darwin": "Cypress.app",
-        "//conditions:default": "Cypress",
-    }),
+    src =  "%{COPY_DIRECTORY_SRC}",
+    out = "Cypress",
     tags = ["manual"]
 )
 
@@ -27,18 +21,12 @@ copy_to_bin(
 
 filegroup(
     name = "files",
-    srcs = select({
-        "@bazel_tools//src/conditions:darwin": ["Cypress.app", "binary_state.json"],
-        "//conditions:default": [":cypress_binary", ":binary_state_file"]
-    }),
+    srcs = [":cypress_binary", ":binary_state_file"],
     visibility = ["//visibility:public"],
 )
 
 cypress_toolchain(
     name = "cypress_toolchain", 
-    target_tool = select({
-        "@bazel_tools//src/conditions:darwin": "Cypress.app/Contents/MacOS/Cypress",
-        "//conditions:default": "Cypress/Cypress",
-    }),
+    target_tool = "%{TARGET_TOOL}",
     target_tool_files = ":files",
 )

--- a/cypress/private/toolchains_repo.bzl
+++ b/cypress/private/toolchains_repo.bzl
@@ -86,6 +86,12 @@ toolchain(
     toolchain = "@{user_repository_name}_{platform}//:cypress_toolchain",
     toolchain_type = "@aspect_rules_cypress//cypress:toolchain_type",
 )
+toolchain(
+    name = "{platform}_toolchain_target",
+    target_compatible_with = {compatible_with},
+    toolchain = "@{user_repository_name}_{platform}//:cypress_toolchain",
+    toolchain_type = "@aspect_rules_cypress//cypress:toolchain_type",
+)
 """.format(
             platform = platform,
             name = repository_ctx.attr.name,


### PR DESCRIPTION
This PR implements a `target_compatible_with` toolchain to allow for cross-building on Mac and  Linux. The PR follows the discussion in https://github.com/bazelbuild/bazel/issues/19645 and the implementation thereof 
