### PR TITLE
Don't mutate the potentially frozen `tags` list when `disable_sandbox` is `True`.

### DIFF
--- a/cypress/defs.bzl
+++ b/cypress/defs.bzl
@@ -13,7 +13,7 @@ _cypress_test = rule(
 )
 
 def _cypress_test_macro(name, entry_point, cypress, disable_sandbox, **kwargs):
-    tags = list(kwargs.pop("tags", []))
+    tags = kwargs.pop("tags", [])[:]
     if disable_sandbox:
         tags.append("no-sandbox")
     _cypress_test(

--- a/cypress/defs.bzl
+++ b/cypress/defs.bzl
@@ -13,7 +13,7 @@ _cypress_test = rule(
 )
 
 def _cypress_test_macro(name, entry_point, cypress, disable_sandbox, **kwargs):
-    tags = kwargs.pop("tags", [])
+    tags = list(kwargs.pop("tags", []))
     if disable_sandbox:
         tags.append("no-sandbox")
     _cypress_test(


### PR DESCRIPTION
Don't mutate the potentially frozen `tags` list when `disable_sandbox` is `True`.

Trying to fix an error that manifests like this:

```
(15:51:39) ERROR: Traceback (most recent call last):
        File "/mnt/ephemeral/workdir/apps/foo-app/cypress/BUILD.bazel", line 13, column 13, in <toplevel>
                cypress_test(
        File "/mnt/ephemeral/workdir/bazel/defs.bzl", line 947, column 18, in cypress_test
                _cypress_test(
        File "/mnt/ephemeral/output/lattice-control-app/__main__/external/aspect_rules_cypress~/cypress/defs.bzl", line 86, column 24, in cypress_test
                _cypress_test_macro(
        File "/mnt/ephemeral/output/lattice-control-app/__main__/external/aspect_rules_cypress~/cypress/defs.bzl", line 18, column 20, in _cypress_test_macro
                tags.append("no-sandbox")
Error in append: trying to mutate a frozen list value
```

---

### Changes are visible to end-users: no

### Test plan

- Covered by existing test cases
- New test cases added
- Manual testing; please provide instructions so we can reproduce:
